### PR TITLE
fix: npm publishing permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,11 +5,13 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout code
@@ -21,11 +23,10 @@ jobs:
         with:
            node-version: "lts/*"
            cache: "npm"
+           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Build and Publish to NPM
         run: npm run publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adds the `id-token: write` permission to enable OIDC and Trusted
Publishing to NPM

https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
